### PR TITLE
From Devel

### DIFF
--- a/export-ADData.ps1
+++ b/export-ADData.ps1
@@ -40,12 +40,16 @@
   'Guest(s)', 'Domain Users' and trusted 'DOMAIN$'.
  
  .EXAMPLE
-   # Export AD Users and Groups from the Domain basis to CSV files in "C:\ADExport"
-   .\export-ADData.ps1 -DNPath "DC=mydomain,DC=local" -OutPath "C:\ADExport"
+   # Export AD Users and Groups from the Domain root to CSV files in "C:\ADExport", excluding system objects
+   .\export-ADData.ps1 -DNPath "DC=mydomain,DC=local" -OutPath "C:\ADExport" -ExcludeSystemObject
  
  .EXAMPLE
-   # (Not recommended) Export AD Users and Groups, specifying a specific hierarchy base.
+   # Export AD Users and Groups, specifying a specific hierarchy base.
    .\export-ADData.ps1 -DNPath "OU=unit,DC=mydomain,DC=local" -OutPath "C:\ADExport"
+
+ .EXAMPLE
+   # Export AD Computers from the domain root, making the script prompt for output folder via dialog
+   .\export-ADData.ps1 -DNPath "DC=mydomain,DC=local" -Computer
 #>
 [CmdletBinding()]
 param(


### PR DESCRIPTION
## Major Changes in This PR

**export-ADData.ps1**

- Added example of computer export feature which was recently added.

**import-ADData.ps1**

- **Computer import capability:**
  - Added `-Computer` mode argument, with a new `-ComputerFile` parameter.
  - Extended `$reservedWords` to include 'computers', now: 'ou', 'cn', 'dc', 'users', 'computers', and '='.
  - Modified `ConvertDNBase` to accept a `-DefaultContainer` parameter for temporary container name changes, supporting `ManagedBy` registration in Computer import mode. `Get-NewDN` now forwards this parameter to `ConvertDNBase`.
- **Centralized resolution of AD default containers:**
  - AD default container name resolution per mode (User/Group/Computer) is now centralized in the `Get-DefaultContainerName` function for code simplicity.
  - Renamed advanced options `-NoUsersContainer` and `-NoForceUsersContainer` to `-NoDefaultContainer` and `-NoForceDefaultContainer` to also apply to the `Computers` container.
- **Centralized mismatch detection for mode vs. input file name:**
  - The mismatch detection logic is now centralized in the `FileName-WrongType-Warn` function.
- **Improved log clarity for optional property registration failures:**
  - Now outputs both the property name and the attempted value when any `$additionalProperties` registration fails.
  - To maximize clarity, minimized the essential property list in `$new(User|Group|Computer)Params`, moving more properties to `$additionalProperties`.
- **Fixed bug in `-DNPrefix` parameter behavior:**
  - Repaired the `ConvertPrefixToDNPath` function to correctly handle OU/DC conversion.

**README.md**

- Reflected these changes.
